### PR TITLE
Add manual build documentation, support for mods outside the game

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,32 @@ services:
 
 ### Building manually
 
-Coming soon! Follow commands in [Dockerfile](https://github.com/lord-server/panorama/blob/master/Dockerfile) in the meantime.
+Building panorama manually requires go 1.21 or newer, due to its use
+of `log/slog`. Afterwards, build the module with the following
+commands:
+
+```
+go mod download && go mod verify
+go build -v ./cmd/panorama
+```
+
+This builds the panorama binary in `./panorama`. 
+
+### Configuration
+
+An example config is provided in `config.example.toml`. To work
+correctly, panorama needs to know how to connect to the server and how
+to render the world. To connect, you need to specify the postgres
+connection using the `world_dsn` variable, panorama is not yet capable
+of doing this automatically. If you leave `world_dsn` empty, you might
+only receive empty tiles! The node descriptions are obtained from the
+world directory using the output from the `nodes_dump` mod.
+
+The textures and meshes (only .obj currently supported) are fetched
+from the game and mod directories. These are specified using the
+`game_path` and `mod_path`directories. 
+
+
 
 ## License
 

--- a/cmd/panorama/main.go
+++ b/cmd/panorama/main.go
@@ -24,14 +24,13 @@ var args Args
 func fullrender(config config.Config) error {
 	descPath := path.Join(config.System.WorldPath, "nodes_dump.json")
 
-	slog.Info("loading game description", "game", config.System.GamePath, "desc", descPath)
+	slog.Info("loading game description", "game", config.System.GamePath, "mods", config.System.ModPath, "desc", descPath)
 
-	game, err := game.LoadGame(descPath, config.System.GamePath)
+	game, err := game.LoadGame(descPath, config.System.GamePath, config.System.ModPath)
 	if err != nil {
 		slog.Error("unable to load game description", "error", err)
 		return err
 	}
-
 	backend, err := world.NewPostgresBackend(config.System.WorldDSN)
 	if err != nil {
 		slog.Error("unable to connect to world DB", "error", err)

--- a/config.example.toml
+++ b/config.example.toml
@@ -9,6 +9,10 @@ game_path = "/var/lib/panorama/game"
 # Default: "/var/lib/panorama/world"
 world_path = "/var/lib/panorama/world"
 
+# Path to the directory containing the mods
+mod_path = "/var/lib/panorama/mods"
+
+
 # DSN string used for connecting to PostgreSQL
 # Default: ""
 world_dsn = ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Renderer struct {
 
 type System struct {
 	GamePath  string `toml:"game_path"`
+	ModPath   string `toml:"mod_path"`
 	TilesPath string `toml:"tiles_path"`
 	WorldPath string `toml:"world_path"`
 	WorldDSN  string `toml:"world_dsn"`

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -145,7 +145,7 @@ func ResolveNode(descriptor NodeDescriptor, mediaCache *MediaCache) NodeDefiniti
 	return nd
 }
 
-func LoadGame(desc string, path string) (Game, error) {
+func LoadGame(desc string, path string, modpath string) (Game, error) {
 	descJSON, err := os.ReadFile(desc)
 	if err != nil {
 		return Game{}, err
@@ -160,6 +160,10 @@ func LoadGame(desc string, path string) (Game, error) {
 	mediaCache := NewMediaCache()
 
 	err = mediaCache.fetchMedia(path)
+	if err != nil {
+		return Game{}, err
+	}
+	err = mediaCache.fetchMedia(modpath)
 	if err != nil {
 		return Game{}, err
 	}

--- a/internal/game/node.go
+++ b/internal/game/node.go
@@ -27,6 +27,7 @@ const (
 )
 
 var DrawTypeNames = map[string]DrawType{
+	"node":                      DrawTypeNormal,
 	"normal":                    DrawTypeNormal,
 	"airlike":                   DrawTypeAirlike,
 	"liquid":                    DrawTypeLiquid,
@@ -38,13 +39,14 @@ var DrawTypeNames = map[string]DrawType{
 	"allfaces_optional":         DrawTypeAllFaces,
 	"torchlike":                 DrawTypeTorchlike,
 	"signlike":                  DrawTypeSignlike,
-	"plantlike":                 DrawTypePlantlike,
-	"firelike":                  DrawTypeFirelike,
-	"fencelike":                 DrawTypeFencelike,
-	"raillike":                  DrawTypeRaillike,
-	"nodebox":                   DrawTypeNodeBox,
-	"mesh":                      DrawTypeMesh,
-	"plantlike_rooted":          DrawTypePlantlikeRooted,
+	//	"plantlike":                 DrawTypePlantlike,
+	"plantlike":        DrawTypeAllFaces,
+	"firelike":         DrawTypeFirelike,
+	"fencelike":        DrawTypeFencelike,
+	"raillike":         DrawTypeRaillike,
+	"nodebox":          DrawTypeNodeBox,
+	"mesh":             DrawTypeMesh,
+	"plantlike_rooted": DrawTypePlantlikeRooted,
 }
 
 func (t DrawType) IsLiquid() bool {


### PR DESCRIPTION
This adds documentation on how to build this software manually, and adds support for fetching textures from mods outside the game path.

Furthermore, the plantlike render type is rendered as allfaces until a better solution is found.